### PR TITLE
Remove dict comprehensions for 2.6 compatibility

### DIFF
--- a/luminoso_api/auth.py
+++ b/luminoso_api/auth.py
@@ -133,7 +133,8 @@ class LuminosoAuth(requests.auth.AuthBase):
         (scheme, netloc, path, paramstring, querystring, fragment) = \
             urlparse(req.url)
         url_dict = parse_qs(querystring, keep_blank_values=True)
-        req_params = {key: value[0] for (key, value) in url_dict.items()}
+        req_params = dict((key, value[0]) 
+                          for (key, value) in url_dict.items())
 
         # Set the key id
         req_params['key_id'] = self._key_id
@@ -150,7 +151,8 @@ class LuminosoAuth(requests.auth.AuthBase):
         if content_type == 'application/x-www-form-urlencoded':
             # These are form parameters for a POST or PUT or something
             form_dict = parse_qs(req.body, keep_blank_values=True)
-            form_params = {key: value[0] for (key, value) in form_dict.items()}
+            form_params = dict((key, value[0]) 
+                               for (key, value) in form_dict.items())
             params.update(form_params)
             content_type = None
         elif content_type == 'application/json':


### PR DESCRIPTION
Tested in 2.6, 2.7, and 3.4. And by "tested", I mean, "lumi-upload seems to work". However, there's still a problem in ftfy in 2.6.
