### PR TITLE
Prepare for the move to "https://analytics.luminoso.com/api/v4/"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,21 @@
+Version 0.5 (2015-12-03)
+
+These changes correlate with moving the api from https://api.luminoso.com/v4
+to https://analytics.luminoso.com/api/v4.
+
+  * Client changes
+
+    - Documentation updated with new URL.
+    - URL_BASE updated in the constants (with API_VERSION and API_HOST being
+      removed as unnecessary)
+    - The logic for getting the "root url" when setting up a client is now
+      different; it uses /api/v4 unless the given URL is using /v4 (in which
+      case it uses /v4 but issues a warning about the new URL).
+
+  * Upload script changes
+
+    - Removed --local as an option, which was only usable internally.
+
 Version 0.4.8 (2015-10-20)
 
   * Client changes

--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ account_id under /projects:
 >>> projects = LuminosoClient.connect(username='testuser')
 Password: ...
 >>> print(projects)
-<LuminosoClient for https://api.luminoso.com/v4/projects/lumi-test/>
+<LuminosoClient for https://analytics.luminoso.com/api/v4/projects/lumi-test/>
 ```
 
 HTTP methods
 ------------
 
-The URLs you can communicate with are documented at https://api.luminoso.com/v4.
+The URLs you can communicate with are documented at https://analytics.luminoso.com/api/v4.
 That documentation is the authoritative source for what you can do with the
 API, and this Python code is just here to help you do it.
 

--- a/luminoso_api/client.py
+++ b/luminoso_api/client.py
@@ -21,14 +21,14 @@ class LuminosoClient(object):
     A tool for making authenticated requests to the Luminoso API version 4.
 
     A LuminosoClient is a thin wrapper around the REST API documented at
-    https://api.luminoso.com/v4. As such, you interact with it by calling its
-    methods that correspond to HTTP methods: `.get(url)`, `.post(url)`,
-    `.put(url)`, `.patch(url)`, and `.delete(url)`.
+    https://analytics.luminoso.com/api/v4/. As such, you interact with it by
+    calling its methods that correspond to HTTP methods: `.get(url)`,
+    `.post(url)`, `.put(url)`, `.patch(url)`, and `.delete(url)`.
 
     These URLs are relative to a 'base URL' for the LuminosoClient. For
     example, you can make requests for a specific account's projects
     by creating a LuminosoClient for
-    `https://api.luminoso.com/v4/projects/<account_id>`,
+    `https://analytics.luminoso.com/api/v4/projects/<account_id>`,
     or you can go deeper to create a client that makes requests for a
     specific project.
 
@@ -42,10 +42,11 @@ class LuminosoClient(object):
     `LuminosoClient.connect()` static method.
 
     In addition to the base URL, the LuminosoClient has a `root_url`,
-    pointing to the root of the API, such as https://api.luminoso.com/v4.
-    This is used, for example, as a starting point for the `change_path`
-    method: when it gets a path starting with `/`, it will go back to the
-    `root_url` instead of adding to the existing URL.
+    pointing to the root of the API, such as
+    https://analytics.luminoso.com/api/v4. This is used, for example, as a
+    starting point for the `change_path` method: when it gets a path starting
+    with `/`, it will go back to the `root_url` instead of adding to the
+    existing URL.
     """
     def __init__(self, session, url):
         """
@@ -76,8 +77,8 @@ class LuminosoClient(object):
             client = LuminosoClient.connect(username=username)
 
         If the URL is simply a path, omitting the scheme and domain, then
-        it will default to https://api.luminoso.com/v4/, which is probably what
-        you want:
+        it will default to https://analytics.luminoso.com/api/v4/, which is
+        probably what you want:
 
             client = LuminosoClient.connect('/projects/public', username=username)
 
@@ -358,9 +359,9 @@ class LuminosoClient(object):
         Return a new LuminosoClient for a subpath of this one.
 
         For example, you might want to start with a LuminosoClient for
-        `https://api.luminoso.com/v4/`, then get a new one for
-        `https://api.luminoso.com/v4/projects/myaccount/myproject_id`. You
-        accomplish that with the following call:
+        `https://analytics.luminoso.com/api/v4/`, then get a new one for
+        `https://analytics.luminoso.com/api/v4/projects/myaccount/myprojectid`.
+        You accomplish that with the following call:
 
             newclient = client.change_path('projects/myaccount/myproject_id')
 
@@ -489,12 +490,19 @@ def get_token_filename():
 
 def get_root_url(url):
     """
-    If we have to guess a root URL, assume it contains the scheme,
-    hostname, and one path component, as in "https://api.luminoso.com/v4".
+    Guessing the root URL is slightly complicated, because the API may be at
+    /v4 or at /api/v4, depending on whether you're accessing the API through
+    its old URL or its new one.
     """
     # make sure it's a complete URL, not a relative one
-    assert ':' in url
-    return '/'.join(url.split('/')[:4])
+    if '://' not in url:
+        raise ValueError('Please supply a full URL, beginning with http:// '
+                         'or https:// .')
+    if 'v4' not in url:
+        # We presumably have just, e.g., https://analytics.luminoso.com/ .
+        # Redirect properly.
+        return ensure_trailing_slash(url) + 'api/v4'
+    return url[:url.find('v4') + 2]
 
 def ensure_trailing_slash(url):
     """

--- a/luminoso_api/client.py
+++ b/luminoso_api/client.py
@@ -58,7 +58,8 @@ class LuminosoClient(object):
         """
         self.session = session
         self.url = ensure_trailing_slash(url)
-        self.root_url = get_root_url(url)
+        # Don't warn this time; warning happened in connect()
+        self.root_url = get_root_url(url, warn=False)
 
     def __repr__(self):
         return '<LuminosoClient for %s>' % self.url
@@ -488,21 +489,34 @@ def get_token_filename():
                         '.luminoso',
                         'tokens.json')
 
-def get_root_url(url):
+def get_root_url(url, warn=True):
     """
     Guessing the root URL is slightly complicated, because the API may be at
     /v4 or at /api/v4, depending on whether you're accessing the API through
     its old URL or its new one.
     """
-    # make sure it's a complete URL, not a relative one
-    if '://' not in url:
+    parsed_url = urlparse(url)
+
+    # Make sure it's a complete URL, not a relative one.
+    if not parsed_url.scheme:
         raise ValueError('Please supply a full URL, beginning with http:// '
                          'or https:// .')
-    if 'v4' not in url:
-        # We presumably have just, e.g., https://analytics.luminoso.com/ .
-        # Redirect properly.
-        return ensure_trailing_slash(url) + 'api/v4'
-    return url[:url.find('v4') + 2]
+
+    # If the path starts with v4, use that for the base URL, but issue a
+    # warning about the URL moving.
+    if parsed_url.path.startswith('/v4'):
+        if warn:
+            logger.warning('While the old URL will continue to work, please '
+                           'be aware that the Luminoso API has moved to %s',
+                           URL_BASE)
+        return '%s://%s/v4' % (parsed_url.scheme, parsed_url.netloc)
+
+    # Otherwise, use api/v4 for the base URL, but if the path didn't already
+    # start with that, issue a warning.
+    root_url = '%s://%s/api/v4' % (parsed_url.scheme, parsed_url.netloc)
+    if warn and not parsed_url.path.startswith('/api/v4'):
+        logger.warning('Using %s as the root url' % root_url)
+    return root_url
 
 def ensure_trailing_slash(url):
     """

--- a/luminoso_api/constants.py
+++ b/luminoso_api/constants.py
@@ -1,4 +1,4 @@
 from __future__ import unicode_literals
-API_VERSION=4
-API_HOST='api.luminoso.com'
-URL_BASE='https://%s/v%d' % (API_HOST, API_VERSION)
+API_VERSION = 4
+API_HOST = 'analytics.luminoso.com'
+URL_BASE = 'https://%s/api/v%d' % (API_HOST, API_VERSION)

--- a/luminoso_api/constants.py
+++ b/luminoso_api/constants.py
@@ -1,4 +1,2 @@
 from __future__ import unicode_literals
-API_VERSION = 4
-API_HOST = 'analytics.luminoso.com'
-URL_BASE = 'https://%s/api/v%d' % (API_HOST, API_VERSION)
+URL_BASE = 'https://analytics.luminoso.com/api/v4'

--- a/luminoso_api/json_stream.py
+++ b/luminoso_api/json_stream.py
@@ -16,7 +16,8 @@ Its input can be:
 - Or a JSON stream, which will effectively be validated before uploading.
 
 The dictionary keys in JSON, or the column labels in CSV, should be the
-document properties defined in the documentation at https://api.luminoso.com/v4.
+document properties defined in the documentation at
+https://analytics.luminoso.com/api/v4.
 """
 from __future__ import unicode_literals
 import json

--- a/luminoso_api/upload.py
+++ b/luminoso_api/upload.py
@@ -1,10 +1,8 @@
 from __future__ import print_function, unicode_literals
 from itertools import islice, chain
 from luminoso_api import LuminosoClient
+from luminoso_api.constants import URL_BASE
 from luminoso_api.json_stream import transcode_to_stream, stream_json_lines
-
-ROOT_URL = 'https://analytics.luminoso.com/api/v4/'
-LOCAL_URL = 'http://localhost:5000/api/v4'
 
 
 # http://code.activestate.com/recipes/303279-getting-items-in-batches/
@@ -97,11 +95,7 @@ def main():
         action="store_true")
     parser.add_argument('-a', '--api-url',
         help="Specify an alternate API url",
-        default=ROOT_URL)
-    parser.add_argument('-l', '--local',
-        help="Run on localhost:5000 instead of the default API server "
-             "(overrides -a)",
-        action="store_true")
+        default=URL_BASE)
     parser.add_argument('-r', '--readers', metavar='LANG=READER',
         help="Custom reader to use, in a form such as "
              "'ja=mecab.ja,en=freeling.en'")
@@ -115,9 +109,6 @@ def main():
              "Other shortcuts are 'epoch' for epoch time or 'us-standard' for "
              "'%%m/%%d/%%y'")
     args = parser.parse_args()
-    url = args.api_url
-    if args.local:
-        url = LOCAL_URL
 
     reader_dict = {}
     if args.readers:
@@ -139,7 +130,7 @@ def main():
     else:
         date_format = args.date_format
 
-    upload_file(args.filename, url, args.account, args.project_name,
+    upload_file(args.filename, args.api_url, args.account, args.project_name,
                 reader_dict, username=args.username, password=args.password,
                 append=args.append, stage=args.stage,
                 date_format=date_format)

--- a/luminoso_api/upload.py
+++ b/luminoso_api/upload.py
@@ -86,24 +86,31 @@ def main():
     parser.add_argument('filename')
     parser.add_argument('account')
     parser.add_argument('project_name')
-    parser.add_argument('--append',
+    parser.add_argument(
+        '--append',
         help=("If append flag is used, upload documents to existing project,"
               "rather than creating a new project."),
         action="store_true")
-    parser.add_argument('-s', '--stage',
+    parser.add_argument(
+        '-s', '--stage',
         help=("If stage flag is used, just upload docs, don't recalculate."),
         action="store_true")
-    parser.add_argument('-a', '--api-url',
+    parser.add_argument(
+        '-a', '--api-url',
         help="Specify an alternate API url",
         default=URL_BASE)
-    parser.add_argument('-r', '--readers', metavar='LANG=READER',
+    parser.add_argument(
+        '-r', '--readers', metavar='LANG=READER',
         help="Custom reader to use, in a form such as "
              "'ja=mecab.ja,en=freeling.en'")
-    parser.add_argument('-u', '--username', default=None,
+    parser.add_argument(
+        '-u', '--username', default=None,
         help="username (defaults to your username on your computer)")
-    parser.add_argument('-p', '--password', default=None,
+    parser.add_argument(
+        '-p', '--password', default=None,
         help="password (you can leave this out and type it in later)")
-    parser.add_argument('-d', '--date-format', default='iso',
+    parser.add_argument(
+        '-d', '--date-format', default='iso',
         help="format string for parsing dates, following http://strftime.org/. "
              "Default is 'iso', which is '%%Y-%%m-%%dT%%H:%%M:%%S+00:00'. "
              "Other shortcuts are 'epoch' for epoch time or 'us-standard' for "

--- a/luminoso_api/upload.py
+++ b/luminoso_api/upload.py
@@ -3,8 +3,8 @@ from itertools import islice, chain
 from luminoso_api import LuminosoClient
 from luminoso_api.json_stream import transcode_to_stream, stream_json_lines
 
-ROOT_URL = 'https://api.luminoso.com/v4'
-LOCAL_URL = 'http://localhost:5000/v4'
+ROOT_URL = 'https://analytics.luminoso.com/api/v4/'
+LOCAL_URL = 'http://localhost:5000/api/v4'
 
 
 # http://code.activestate.com/recipes/303279-getting-items-in-batches/

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-VERSION = "0.4.8"
+VERSION = "0.5"
 
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
Changes in this patch:
* Changing the URL_BASE as defined in constants.py
* Updating the URL in various docstrings (and a global in upload.py)
* Changing get_root_url to not assume that there is exactly one path component;
  rather, it now assumes that "v4" is part of the path.  (If and when the API
  changes to /api/v5/, we will have a new version of the client to go with it.)