### PR TITLE
Prepare for the move to "https://analytics.luminoso.com/api/v4/"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+Version 0.5a1 (2015-12-09)
+
+  * Client changes
+
+    - In preparation for moving the API from api.luminoso.com/v4 to
+      analytics.luminoso.com/api/v4, change the logic in get_root_url to
+      temporarily support the latter while still preferring the former.
+
 Version 0.4.8 (2015-10-20)
 
   * Client changes

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-VERSION = "0.4.8"
+VERSION = "0.5a1"
 
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
This changes the logic of get_root_url so that /api/v4 routes can be used as
the root_url of a client, while still defaulting to /v4.