### PR TITLE
Keep test setup realistic

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -47,7 +47,7 @@ PROJECT_RECORD = {
     'project_id': 'projid',
     'account_id': 'account',
     'document_count': 2,
-    'permissions': ['*']
+    'permissions': ['read', 'write', 'create']
 }
 
 EXPANDED_DOCS = [


### PR DESCRIPTION
The API will no longer be returning '*' in lists of permissions, so
let's drop it from the example in this test.