### PR TITLE
Better token handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+Version 2.1.0 (2020-09-04)
+
+  * Removed the ability to specify a token when using lumi-api, lumi-download,
+    and lumi-upload.
+
+  * Added a new command, `lumi-save-token`, as an interface to LuminosoClient's
+    existing "save_token" functionality.
+
 Version 2.0.1 (2020-07-10)
 
   * Added a new method, `wait_for_sentiment_build`, to allow users to wait for

--- a/README.md
+++ b/README.md
@@ -181,31 +181,28 @@ API:
 
 ```
 # get a project list
-lumi-api -b https://daylight.luminoso.com/api/v5/ -t my_token get /projects
+lumi-api -b https://daylight.luminoso.com/api/v5/ get /projects
 
 # get a project list in CSV format
-lumi-api -b https://daylight.luminoso.com/api/v5/ -t my_token get /projects -c
-
-# get a project list and save the token so the next call wouldn't need "-t my_token" parameter
-lumi-api -b https://daylight.luminoso.com/api/v5/ -t my_token -s get /projects -c
+lumi-api -b https://daylight.luminoso.com/api/v5/ get /projects -c
 
 # create a project
-lumi-api -b https://daylight.luminoso.com/api/v5/ -t my_token post /projects/ -p 'name=project name' -p 'language=en'
+lumi-api -b https://daylight.luminoso.com/api/v5/ post /projects/ -p 'name=project name' -p 'language=en'
 
 # upload documents
 # my_data.json format: {"docs":[{"text": "..", "title": "..", "metadata": [..]}, {"text": "..", "title": "..", "metadata": [..]}]}
-lumi-api -b https://daylight.luminoso.com/api/v5/ -t my_tokens post /projects/my_project_id/upload my_data.json
+lumi-api -b https://daylight.luminoso.com/api/v5/ post /projects/my_project_id/upload my_data.json
 
 # build project
 # this takes time, if you want to be notified via email when the build is done, add -j '{"notify": true}' parameter
-lumi-api -b https://daylight.luminoso.com/api/v5/ -t my_tokens post /projects/my_project_id/build
+lumi-api -b https://daylight.luminoso.com/api/v5/ post /projects/my_project_id/build
 
 # get concepts from project
-lumi-api -b https://daylight.luminoso.com/api/v5/ -t my_tokens get /projects/my_project_id/concepts
+lumi-api -b https://daylight.luminoso.com/api/v5/ get /projects/my_project_id/concepts
 
 # get project's match counts
-lumi-api -b https://daylight.luminoso.com/api/v5/ -t my_token get /projects/my_project_id/concepts/match_counts
+lumi-api -b https://daylight.luminoso.com/api/v5/ get /projects/my_project_id/concepts/match_counts
 
 # create a saved concept
-lumi-api -b https://daylight.luminoso.com/api/v5/ -t my_token post /projects/my_project_id/concepts/saved -j '{"concepts": [{"texts": ["My new concept text"]}]}'
+lumi-api -b https://daylight.luminoso.com/api/v5/ post /projects/my_project_id/concepts/saved -j '{"concepts": [{"texts": ["My new concept text"]}]}'
 ```

--- a/luminoso_api/v5_cli.py
+++ b/luminoso_api/v5_cli.py
@@ -4,7 +4,6 @@ import json
 import os
 import sys
 from signal import signal, SIGPIPE, SIG_DFL
-from urllib.parse import urlparse
 
 from .v5_client import LuminosoClient
 from .v5_constants import URL_BASE
@@ -75,10 +74,6 @@ def _main(*vargs):
     )
     parser.add_argument('-b', '--base-url', default=URL_BASE,
                         help="API root url, default: %s" % URL_BASE)
-    parser.add_argument('-t', '--token', help="API authentication token")
-    parser.add_argument('-s', '--save-token', action='store_true',
-                        help="save --token for --base-url to"
-                             " ~/.luminoso/tokens.json")
     parser.add_argument('-p', '--param', action='append', default=[],
                         help="key=value parameters")
     parser.add_argument('-j', '--json-body', help="JSON object parameter")
@@ -90,13 +85,7 @@ def _main(*vargs):
     parser.add_argument('input_file', nargs='?', type=open)
 
     args = parser.parse_args(vargs)
-    if args.save_token:
-        if not args.token:
-            raise ValueError("error: no token provided")
-        LuminosoClient.save_token(args.token,
-                                  domain=urlparse(args.base_url).netloc)
-
-    client = LuminosoClient.connect(url=args.base_url, token=args.token,
+    client = LuminosoClient.connect(url=args.base_url,
                                     user_agent_suffix='lumi-cli')
 
     if args.method == 'delete':

--- a/luminoso_api/v5_cli.py
+++ b/luminoso_api/v5_cli.py
@@ -74,6 +74,8 @@ def _main(*vargs):
     )
     parser.add_argument('-b', '--base-url', default=URL_BASE,
                         help="API root url, default: %s" % URL_BASE)
+    parser.add_argument('-f', '--token-file',
+                        help='file where an API token was saved')
     parser.add_argument('-p', '--param', action='append', default=[],
                         help="key=value parameters")
     parser.add_argument('-j', '--json-body', help="JSON object parameter")
@@ -85,8 +87,11 @@ def _main(*vargs):
     parser.add_argument('input_file', nargs='?', type=open)
 
     args = parser.parse_args(vargs)
-    client = LuminosoClient.connect(url=args.base_url,
-                                    user_agent_suffix='lumi-cli')
+    client = LuminosoClient.connect(
+        url=args.base_url,
+        token_file=args.token_file,
+        user_agent_suffix='lumi-cli'
+    )
 
     if args.method == 'delete':
         confirm = input('confirm %s %s? [Y/n] ' % (args.method, args.path))

--- a/luminoso_api/v5_download.py
+++ b/luminoso_api/v5_download.py
@@ -2,7 +2,6 @@ import argparse
 import json
 import sys
 import os
-from urllib.parse import urlparse
 from tqdm import tqdm
 
 from .v5_client import LuminosoClient
@@ -112,13 +111,6 @@ def _main(argv):
              ' document vectors',
         action='store_true',
     )
-    parser.add_argument('-t', '--token', help='API authentication token')
-    parser.add_argument(
-        '-s',
-        '--save-token',
-        action='store_true',
-        help='save --token for --base-url to ~/.luminoso/tokens.json',
-    )
     parser.add_argument(
         'project_id', help='The ID of the project in the Daylight API'
     )
@@ -127,14 +119,9 @@ def _main(argv):
         help='The JSON lines (.jsons) file to write to'
     )
     args = parser.parse_args(argv)
-    if args.save_token:
-        if not args.token:
-            raise ValueError("error: no token provided")
-        LuminosoClient.save_token(args.token,
-                                  domain=urlparse(args.base_url).netloc)
 
     client = LuminosoClient.connect(
-        url=args.base_url, token=args.token, user_agent_suffix='lumi-download'
+        url=args.base_url, user_agent_suffix='lumi-download'
     )
     proj_client = client.client_for_path('projects/{}'.format(args.project_id))
     download_docs(proj_client, args.output_file, args.expanded)

--- a/luminoso_api/v5_download.py
+++ b/luminoso_api/v5_download.py
@@ -105,6 +105,8 @@ def _main(argv):
         default=URL_BASE,
         help='API root url, default: %s' % URL_BASE,
     )
+    parser.add_argument('-f', '--token-file',
+                        help='file where an API token was saved')
     parser.add_argument(
         '-e', '--expanded',
         help="Include Luminoso's analysis of each document, such as terms and"
@@ -121,7 +123,8 @@ def _main(argv):
     args = parser.parse_args(argv)
 
     client = LuminosoClient.connect(
-        url=args.base_url, user_agent_suffix='lumi-download'
+        url=args.base_url, token_file=args.token_file,
+        user_agent_suffix='lumi-download'
     )
     proj_client = client.client_for_path('projects/{}'.format(args.project_id))
     download_docs(proj_client, args.output_file, args.expanded)

--- a/luminoso_api/v5_save_token.py
+++ b/luminoso_api/v5_save_token.py
@@ -1,0 +1,36 @@
+import argparse
+import os
+import sys
+from urllib.parse import urlparse
+
+from .v5_client import LuminosoClient, get_token_filename
+from .v5_constants import URL_BASE
+
+
+def main():
+    default_domain_base = urlparse(URL_BASE).netloc
+    default_token_filename = get_token_filename()
+    parser = argparse.ArgumentParser(
+        description='Save a token for the Luminoso Daylight API.',
+    )
+    parser.add_argument('token',
+                        help='API token (see "Settings - Tokens" in the UI)')
+    parser.add_argument('domain', default=default_domain_base,
+                        help=f'API domain, default {default_domain_base}',
+                        nargs='?')
+    parser.add_argument('-f', '--token_file', default=default_token_filename,
+                        help=(f'File in which to store the token, default'
+                              f' {default_token_filename}'))
+    args = parser.parse_args()
+
+    # Make this as friendly as possible: turn any of "daylight.luminoso.com",
+    # "daylight.luminoso.com/api/v5", or "http://daylight.luminoso.com/", into
+    # just the domain
+    domain = args.domain
+    if '://' in domain:
+        domain = urlparse(domain).netloc
+    else:
+        domain = domain.split('/')[0]
+
+    LuminosoClient.save_token(args.token, domain=domain,
+                              token_file=args.token_file)

--- a/luminoso_api/v5_upload.py
+++ b/luminoso_api/v5_upload.py
@@ -2,7 +2,6 @@ import argparse
 import json
 import time
 import sys
-from urllib.parse import urlparse
 from itertools import islice, chain
 from tqdm import tqdm
 
@@ -144,13 +143,6 @@ def _main(argv):
         default='en',
         help='The language code for the language the text is in. Default: en',
     )
-    parser.add_argument('-t', '--token', help="API authentication token")
-    parser.add_argument(
-        '-s',
-        '--save-token',
-        action='store_true',
-        help='save --token for --base-url to ~/.luminoso/tokens.json',
-    )
     parser.add_argument(
         'input_filename',
         help='The JSON-lines (.jsons) file of documents to upload',
@@ -162,14 +154,9 @@ def _main(argv):
         help='What the project should be called',
     )
     args = parser.parse_args(argv)
-    if args.save_token:
-        if not args.token:
-            raise ValueError("error: no token provided")
-        LuminosoClient.save_token(args.token,
-                                  domain=urlparse(args.base_url).netloc)
 
     client = LuminosoClient.connect(
-        url=args.base_url, token=args.token, user_agent_suffix='lumi-upload'
+        url=args.base_url, user_agent_suffix='lumi-upload'
     )
 
     name = args.project_name

--- a/luminoso_api/v5_upload.py
+++ b/luminoso_api/v5_upload.py
@@ -132,6 +132,11 @@ def _main(argv):
         help='API root url, default: %s' % URL_BASE,
     )
     parser.add_argument(
+        '-f',
+        '--token-file',
+        help='file where an API token was saved'
+    )
+    parser.add_argument(
         '-a',
         '--account-id',
         default=None,
@@ -156,7 +161,8 @@ def _main(argv):
     args = parser.parse_args(argv)
 
     client = LuminosoClient.connect(
-        url=args.base_url, user_agent_suffix='lumi-upload'
+        url=args.base_url, token_file=args.token_file,
+        user_agent_suffix='lumi-upload'
     )
 
     name = args.project_name

--- a/luminoso_api/version.py
+++ b/luminoso_api/version.py
@@ -1,2 +1,2 @@
 # Remember to change both this and the version in setup.py!
-VERSION = '2.0.1'
+VERSION = '2.1.0'

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     entry_points={
         'console_scripts': [
             'lumi-api = luminoso_api.v5_cli:main',
+            'lumi-save-token = luminoso_api.v5_save_token:main',
             'lumi-upload = luminoso_api.v5_upload:main',
             'lumi-download = luminoso_api.v5_download:main',
         ]},

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-VERSION = "2.0.1"
+VERSION = "2.1.0"
 
 from setuptools import setup, find_packages
 import sys


### PR DESCRIPTION
The motivation here is primarily one of security: allowing `--token` to be specified in a command-line interface is potentially an encouragement either to hardcode the token into scripts that use the interface, or to constantly be pasting the token interactively at the command line.  Because the LuminosoClient already has the capability to save a token in a file (so that it only ever needs to be pasted once), we'd rather that this be the workflow that people use.