### PR TITLE
Use "field" parameter for "GET /docs" in the lumi-download script

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@ Version 2.1.0 (2020-09-04)
   * Added a new command, `lumi-save-token`, as an interface to LuminosoClient's
     existing "save_token" functionality.
 
+  * Tweaked the `lumi-download` command to improve performance by using the
+    (relatively new) `fields` parameter on the document-downloading endpoint.
+
 Version 2.0.1 (2020-07-10)
 
   * Added a new method, `wait_for_sentiment_build`, to allow users to wait for

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -75,7 +75,10 @@ REPETITIVE_DOC = {'title': 'Yadda', 'text': 'yadda yadda', 'metadata': []}
 
 
 def doc_paring_callback(request, context):
-
+    # The "qs" attribute on the mock request is the result of running
+    # urllib.parse.parse_qs on the query string, which maps the query variable
+    # names to lists of their values; thus we want the json-decoded value of
+    # the first (and only) element of the "fields" parameter
     fields = json.loads(request.qs['fields'][0])
     docs = [
         {field: value for field, value in doc.items() if field in fields}

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -24,7 +24,7 @@ PROJECT_RECORD = {
     'permissions': ['read', 'write', 'create']
 }
 
-RAW_DOCS = [
+FULL_DOCS = [
     {
         'title': 'Document 1',
         'text': 'hello',
@@ -75,10 +75,11 @@ REPETITIVE_DOC = {'title': 'Yadda', 'text': 'yadda yadda', 'metadata': []}
 
 
 def doc_paring_callback(request, context):
+
     fields = json.loads(request.qs['fields'][0])
     docs = [
         {field: value for field, value in doc.items() if field in fields}
-        for doc in RAW_DOCS
+        for doc in FULL_DOCS
     ]
     return {'result': docs, 'total_count': 2, 'filter_count': 2, 'search': None}
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,39 +1,13 @@
+import json
+import tempfile
+
 from luminoso_api.v5_client import LuminosoClient
 from luminoso_api.v5_upload import iterate_json_lines
 from luminoso_api.v5_download import (
     iterate_docs, download_docs, DOCS_PER_BATCH
 )
 
-import tempfile
-
 BASE_URL = 'http://mock-api.localhost/api/v5/'
-RESPONSE = {
-    'result': [
-        {
-            'title': 'Document 1',
-            'text': 'hello',
-            'terms': [{'term_id': 'hello|en', 'start': 0, 'end': 5}],
-            'fragments': [],
-            'metadata': [],
-            'vector': 'AAAA',
-            'doc_id': 'uuid-0',
-            'match_score': None
-        },
-        {
-            'title': 'Document 2',
-            'text': 'hello',
-            'terms': [{'term_id': 'hello|en', 'start': 0, 'end': 5}],
-            'fragments': [],
-            'metadata': [],
-            'vector': 'AAAA',
-            'doc_id': 'uuid-1',
-            'match_score': None
-        },
-    ],
-    'total_count': 2,
-    'filter_count': 2,
-    'search': None
-}
 
 PROJECT_RECORD = {
     'name': 'Test Project',
@@ -49,6 +23,29 @@ PROJECT_RECORD = {
     'document_count': 2,
     'permissions': ['read', 'write', 'create']
 }
+
+RAW_DOCS = [
+    {
+        'title': 'Document 1',
+        'text': 'hello',
+        'terms': [{'term_id': 'hello|en', 'start': 0, 'end': 5}],
+        'fragments': [],
+        'metadata': [],
+        'vector': 'AAAA',
+        'doc_id': 'uuid-0',
+        'match_score': None
+    },
+    {
+        'title': 'Document 2',
+        'text': 'hello',
+        'terms': [{'term_id': 'hello|en', 'start': 0, 'end': 5}],
+        'fragments': [],
+        'metadata': [],
+        'vector': 'AAAA',
+        'doc_id': 'uuid-1',
+        'match_score': None
+    },
+]
 
 EXPANDED_DOCS = [
     {
@@ -77,12 +74,22 @@ CONCISE_DOCS = [
 REPETITIVE_DOC = {'title': 'Yadda', 'text': 'yadda yadda', 'metadata': []}
 
 
+def doc_paring_callback(request, context):
+    fields = json.loads(request.qs['fields'][0])
+    docs = [
+        {field: value for field, value in doc.items() if field in fields}
+        for doc in RAW_DOCS
+    ]
+    return {'result': docs, 'total_count': 2, 'filter_count': 2, 'search': None}
+
+
 def test_iteration(requests_mock):
     """
     Test iterating over the documents in a project.
     """
     requests_mock.get(BASE_URL + 'projects/projid/', json=PROJECT_RECORD)
-    requests_mock.get(BASE_URL + 'projects/projid/docs/', json=RESPONSE)
+    requests_mock.get(BASE_URL + 'projects/projid/docs/',
+                      json=doc_paring_callback)
     client = LuminosoClient.connect(BASE_URL + 'projects/projid', token='fake')
 
     docs = list(iterate_docs(client, progress=False))
@@ -123,7 +130,8 @@ def test_writing(requests_mock):
     Test writing downloaded documents to a JSON-lines file.
     """
     requests_mock.get(BASE_URL + 'projects/projid/', json=PROJECT_RECORD)
-    requests_mock.get(BASE_URL + 'projects/projid/docs/', json=RESPONSE)
+    requests_mock.get(BASE_URL + 'projects/projid/docs/',
+                      json=doc_paring_callback)
     client = LuminosoClient.connect(BASE_URL + 'projects/projid', token='fake')
 
     with tempfile.TemporaryDirectory() as tempdir:


### PR DESCRIPTION
Since we haven't put 2.1.0 on PyPI yet, let's sneak this change in as well!  On a casual experiment (against daylight-master), 15,000 documents downloaded in three seconds instead of seven.  So this should be a notable performance improvement.