### PR TITLE
Retry more than just once on a 429 error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,7 @@ Version 3.1.1 (2021-07-23)
     429 responses when using multiple threads.
 
     Please note that we do not recommend using multiple threads for API calls.
-    Aas the rate limit applies to all calls collectively and not separately to
+    As the rate limit applies to all calls collectively and not separately to
     each thread, parallel calls will not be any faster.
 
 Version 3.1.0 (2021-06-14)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+Version 3.1.1 (2021-07-23)
+
+  * Updated the retry adapter to retry nine times instead of once (resulting in
+    a four and a half minute wait before the last retry).  While a single retry
+    after one second is sufficient for most uses, some users reported unhandled
+    429 responses when using multiple threads.
+
+    Please note that we do not recommend using multiple threads for API calls.
+    Aas the rate limit applies to all calls collectively and not separately to
+    each thread, parallel calls will not be any faster.
+
 Version 3.1.0 (2021-06-14)
 
   * Added an adapter to the client to retry after one second upon receiving a

--- a/luminoso_api/v5_client.py
+++ b/luminoso_api/v5_client.py
@@ -134,10 +134,11 @@ class LuminosoClient(object):
         # By default, requests will only retry things like connection timeouts,
         # not any server responses.  We use urllib3's Retry class to say that,
         # if a call failed specifically on a 429 ("too many requests"), wait a
-        # full second and try one more time.  (Technically it tries again
-        # immediately, but then it gets another 429 and tries again at twice
-        # the backoff factor.)
-        retry_strategy = Retry(total=2, backoff_factor=.5,
+        # full second and try again.  (Technically it tries again immediately,
+        # but then it gets another 429 and tries again at twice the backoff
+        # factor.)  The total retries is 10, which is 256 seconds (four
+        # minutes, 16 seconds; or a cumulative wait of 8.5 minutes).
+        retry_strategy = Retry(total=10, backoff_factor=.5,
                                status_forcelist=[429])
         adapter = HTTPAdapter(max_retries=retry_strategy)
         session.mount("https://", adapter)

--- a/luminoso_api/version.py
+++ b/luminoso_api/version.py
@@ -1,2 +1,2 @@
 # Remember to change both this and the version in setup.py!
-VERSION = '3.1.0'
+VERSION = '3.1.1'

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "3.1.0"
+VERSION = "3.1.1"
 
 classifiers = [
     'Intended Audience :: Developers',


### PR DESCRIPTION
Note: another option would be, as Henning said, to "expose the retry count to the client".  I'm inclined to do it this way--see in particular the change to the comment, about how 10 retries is more than enough, and you don't want a client to say, I don't know, "2000 retries" and end up waiting 2.87 × 10<sup>601</sup> seconds.  But it's possible that a client might want to specify a number smaller than 10, so I can be convinced to make the retry count an optional parameter on client creation.