### PR TITLE
Remove B322 from bandit config whitelist

### DIFF
--- a/bandit.config
+++ b/bandit.config
@@ -2,10 +2,7 @@
 tests:
 
 # (optional) list skipped test IDs here, eg '[B101, B406]':
-# We ignore error "B322: use of input" because, as bandit's documentation
-# explains, raw_input is preferred in Python 2, but "input is safe in Python 3"
 skips:
-  [B322]
 
 # We exclude the tests because there are two "errors" throughout them that we
 # don't want to skip as a rule, but which are acceptable in tests.  They are


### PR DESCRIPTION
B322 was "use of input()", which bandit removed as an issue last year (for the same reason we were ignoring it, i.e. it's perfectly safe in Python 3).